### PR TITLE
Merge fix to step5 and step6

### DIFF
--- a/src/qmethod.js
+++ b/src/qmethod.js
@@ -454,11 +454,10 @@ app.controller("step5Ctrl", function ($scope, $rootScope, $state) {
 
 	if (typeof $rootScope.explanations == "undefined") {
 		$rootScope.explanations = {
-			agree: [{ statement: $rootScope.ratings.rating3[0], explanation: null },
-		   		{ statement: $rootScope.ratings.rating3[1], explanation: null }],
-			disagree: [{ statement: $rootScope.ratings.rating_3[0], explanation: null },
-		  	 	{ statement: $rootScope.ratings.rating_3[1], explanation: null }],
+			agree: [{ statement: $rootScope.ratings.rating3[0], explanation: null }, { statement: $rootScope.ratings.rating3[1], explanation: null }],
+			disagree: [{ statement: $rootScope.ratings.rating_3[0], explanation: null }, { statement: $rootScope.ratings.rating_3[1], explanation: null }],
 		};
+
 	}
 	
 	$scope.explanations = $rootScope.explanations;
@@ -534,8 +533,7 @@ app.controller("step6Ctrl", function ($scope, $rootScope, $state) {
 		if (response.classifications === null || response.classifications === undefined){
 			response.classifications = "no_response";
 		} else {
-			// response.classifications = parseClassifications($rootScope.classifications_step3);
-			response.classifications = JSON.stringify($rootScope.classifications_step3);
+			 response.classifications = parseClassifications($rootScope.classifications_step3);
 		}
 
 		if ($rootScope.ratings === null || $rootScope.ratings === undefined) {

--- a/src/qmethod.js
+++ b/src/qmethod.js
@@ -451,11 +451,16 @@ app.controller("step4Ctrl", function ($scope, $rootScope, $state) {
 });
 
 app.controller("step5Ctrl", function ($scope, $rootScope, $state) {
-	$rootScope.explanations = {
-		agree: [{ statement: $rootScope.ratings.rating3[0], explanation: null }, { statement: $rootScope.ratings.rating3[1], explanation: null }],
-		disagree: [{ statement: $rootScope.ratings.rating_3[0], explanation: null }, { statement: $rootScope.ratings.rating_3[1], explanation: null }],
-	};
 
+	if (typeof $rootScope.explanations == "undefined") {
+		$rootScope.explanations = {
+			agree: [{ statement: $rootScope.ratings.rating3[0], explanation: null },
+		   		{ statement: $rootScope.ratings.rating3[1], explanation: null }],
+			disagree: [{ statement: $rootScope.ratings.rating_3[0], explanation: null },
+		  	 	{ statement: $rootScope.ratings.rating_3[1], explanation: null }],
+		};
+	}
+	
 	$scope.explanations = $rootScope.explanations;
 
 	$('#helpModal').modal(show = true);


### PR DESCRIPTION
Fix 'step5' from erasing explanations after going back from 'step6' 
Cause: $rootScope.explanations was getting redefined when coming back
from step6.
Fix: Simple 'if' check to not redefine '$rootScope.explanations'.

Changed classifications from being serialized by JSON.stringify to custom serializing function in order to save storage space.